### PR TITLE
Rename events exchange because of conflict with peatio market

### DIFF
--- a/lib/peatio/mq/events.rb
+++ b/lib/peatio/mq/events.rb
@@ -54,7 +54,7 @@ module Peatio::MQ::Events
     attr_accessor :exchange_name
 
     def initialize
-      @exchange_name = "peatio.events.market"
+      @exchange_name = "peatio.events.ranger"
     end
 
     def connect!


### PR DESCRIPTION
We want to use topic exchanges instead of direct exchanges.